### PR TITLE
fix: Pre-empt accidentally leaking PII in logs

### DIFF
--- a/src/user.rs
+++ b/src/user.rs
@@ -7,7 +7,7 @@ use zitadel_rust_client::v1::{Email, Gender, Idp, ImportHumanUserRequest, Phone,
 use crate::{config::FeatureFlags, FeatureFlag};
 
 /// Source-agnostic representation of a user
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 pub(crate) struct User {
 	/// The user's first name
 	pub(crate) first_name: StringOrBytes,
@@ -37,6 +37,20 @@ impl User {
 	}
 }
 
+impl std::fmt::Debug for User {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("User")
+			.field("first_name", &"***")
+			.field("last_name", &"***")
+			.field("email", &"***")
+			.field("phone", &"***")
+			.field("preferred_username", &"***")
+			.field("external_user_id", &self.external_user_id)
+			.field("enabled", &self.enabled)
+			.finish()
+	}
+}
+
 /// Crate-internal representation of a Zitadel user
 #[derive(Clone, Debug)]
 pub struct ZitadelUser {
@@ -59,7 +73,7 @@ impl ZitadelUser {
 
 	/// Return the name to be used in logs to identify this user
 	pub(crate) fn log_name(&self) -> String {
-		format!("email={}", &self.user_data.email)
+		format!("external_id={}", &self.user_data.external_user_id)
 	}
 
 	/// Get idp link as required by Zitadel
@@ -108,7 +122,7 @@ impl From<ZitadelUser> for ImportHumanUserRequest {
 
 impl Display for ZitadelUser {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-		write!(f, "email={}", &self.user_data.email)
+		write!(f, "external_id={}", &self.user_data.external_user_id)
 	}
 }
 


### PR DESCRIPTION
This allows using the debug impls of our User structs without worrying too much about accidentally exposing PII, trying to start adhering to [our logging policy](https://docs.google.com/document/d/1_ZC0LI01Xp85x4CUIZbKYOeGNNANoL5WGkMJrCwbUOc/edit?tab=t.0).

Note that this means `external_user_id` should *never* contain PII, and as such we'll have to change the CSV source. An issue about this will be opened separately after we merge this - my suggestion would be to add a new column to the CSV sources so that we can simply give users non-sensitive IDs, but we will need to discuss the exact use cases in which we expect to be able to use the CSV source (can't mix it with non-CSV use cases if the external IDs don't match, but more on that on a future ticket).