### PR TITLE
feat: Add filtering by org and project ids

### DIFF
--- a/.config/starte2e.sh
+++ b/.config/starte2e.sh
@@ -20,4 +20,5 @@ fi
 
 # Shut down any still running test-setup first
 docker compose --project-directory ./tests/environment down -v test-setup $ldap_down || true
-docker compose --project-directory ./tests/environment up --wait
+docker compose --project-directory ./tests/environment up --wait \
+	|| (docker compose --project-directory ./tests/environment logs test-setup; exit 1)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -578,17 +578,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
 
 [[package]]
-name = "delegate"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "297806318ef30ad066b15792a8372858020ae3ca2e414ee6c2133b1eb9e9e945"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "der"
 version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4047,13 +4036,12 @@ dependencies = [
 
 [[package]]
 name = "zitadel-rust-client"
-version = "0.2.0"
-source = "git+https://github.com/famedly/zitadel-rust-client?rev=9031cd5db17d5d6faf2e5c9bc7b502a16179883e#9031cd5db17d5d6faf2e5c9bc7b502a16179883e"
+version = "0.3.0"
+source = "git+https://github.com/famedly/zitadel-rust-client?tag=v0.3.0#82995e7dc7f25c3b574e4fb5a521f518ce098285"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
  "cache_control",
- "delegate",
  "famedly_rust_utils",
  "futures",
  "headers",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -92,9 +92,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.89"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86fdf8605db99b54d3cd748a44c6d04df638eb5dafb219b135d0149bd0db01f6"
+checksum = "34ac096ce696dc2fcabef30516bb13c0a68a11d30131d3df6f04711467681b04"
 dependencies = [
  "backtrace",
 ]
@@ -287,6 +287,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "428d9aa8fbc0670b7b8d6030a7fadd0f86151cae55e4dbbece15f3780a3dfaf3"
 
 [[package]]
+name = "cache_control"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bf2a5fb3207c12b5d208ebc145f967fea5cac41a021c37417ccc31ba40f39ee"
+
+[[package]]
 name = "cc"
 version = "1.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -416,6 +422,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "608697df725056feaccfa42cffdaeeec3fccc4ffc38358ecd19b243e716a78e0"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -561,6 +576,17 @@ name = "deadpool-runtime"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
+
+[[package]]
+name = "delegate"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "297806318ef30ad066b15792a8372858020ae3ca2e414ee6c2133b1eb9e9e945"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "der"
@@ -757,6 +783,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "famedly_rust_utils"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bb3dc52a114fda169feb0154271c2edf49e503d4cc487d7304fa9414f8b9654"
+dependencies = [
+ "serde",
+ "thiserror",
+ "tracing",
+ "url",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -783,6 +821,16 @@ name = "fixedbitset"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+
+[[package]]
+name = "flate2"
+version = "1.0.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c936bfdafb507ebbf50b8074c54fa31c5be9a1e7e5f467dd659697041407d07c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "fnv"
@@ -1414,6 +1462,23 @@ name = "itoa"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
+
+[[package]]
+name = "josekit"
+version = "0.8.4"
+source = "git+https://github.com/famedly/josekit-rs.git?rev=5941d0f39d034e9c6d96dc47f391926f5e3038fa#5941d0f39d034e9c6d96dc47f391926f5e3038fa"
+dependencies = [
+ "anyhow",
+ "base64 0.21.7",
+ "flate2",
+ "once_cell",
+ "openssl",
+ "regex",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "time",
+]
 
 [[package]]
 name = "js-sys"
@@ -2755,6 +2820,7 @@ version = "1.0.128"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ff5456707a1de34e7e37f2a6fd3d3f808c318259cbd01ab6377795054b483d8"
 dependencies = [
+ "indexmap 2.6.0",
  "itoa",
  "memchr",
  "ryu",
@@ -3981,15 +4047,19 @@ dependencies = [
 
 [[package]]
 name = "zitadel-rust-client"
-version = "0.1.0"
-source = "git+https://github.com/famedly/zitadel-rust-client#1c12575a5bd13808e1bd225dc02e30cbe9f77b25"
+version = "0.2.0"
+source = "git+https://github.com/famedly/zitadel-rust-client?rev=9031cd5db17d5d6faf2e5c9bc7b502a16179883e#9031cd5db17d5d6faf2e5c9bc7b502a16179883e"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
+ "cache_control",
+ "delegate",
+ "famedly_rust_utils",
  "futures",
  "headers",
  "hyper 0.14.30",
  "hyper-proxy",
+ "josekit",
  "jsonwebtoken",
  "pbjson-types",
  "proxyvars",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ tracing = "0.1.40"
 tracing-subscriber = "0.3.18"
 url = "2.5.2"
 uuid = { version = "1.10.0", features = ["v5"] }
-zitadel-rust-client = { git = "https://github.com/famedly/zitadel-rust-client", rev = "9031cd5db17d5d6faf2e5c9bc7b502a16179883e" }
+zitadel-rust-client = { git = "https://github.com/famedly/zitadel-rust-client", tag = "v0.3.0" }
 wiremock = "0.6.2"
 csv = "1.3.0"
 tempfile = "3.12.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ name = "migrate"
 path = "src/bin/migrate.rs"
 
 [dependencies]
-anyhow = { version = "1.0.81", features = ["backtrace"] }
+anyhow = { version = "1.0.95", features = ["backtrace"] }
 async-trait = "0.1.82"
 base64 = "0.22.1"
 chrono = "0.4.19"
@@ -24,7 +24,7 @@ tracing = "0.1.40"
 tracing-subscriber = "0.3.18"
 url = "2.5.2"
 uuid = { version = "1.10.0", features = ["v5"] }
-zitadel-rust-client = { git = "https://github.com/famedly/zitadel-rust-client", version = "0.1.0" }
+zitadel-rust-client = { git = "https://github.com/famedly/zitadel-rust-client", rev = "9031cd5db17d5d6faf2e5c9bc7b502a16179883e" }
 wiremock = "0.6.2"
 csv = "1.3.0"
 tempfile = "3.12.0"

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ configuration file:
 opt
 ├── certs
 │  └── test-ldap.crt   # The TLS certificate of the LDAP server
-├── config.yaml        # An example can be found in config.sample.yaml
+├── config.yaml        # Example configs can be found in [./sample-configs](./sample-configs)
 └── service-user.json  # Provided by famedly
 ```
 

--- a/src/bin/migrate.rs
+++ b/src/bin/migrate.rs
@@ -1,5 +1,5 @@
 //! This binary is used to migrate user IDs from base64 to hex encoding.
-use std::{path::Path, str::FromStr};
+use std::{path::Path, pin::pin, str::FromStr};
 
 use anyhow::{Context, Result};
 use famedly_sync::{
@@ -41,7 +41,7 @@ async fn main() -> Result<()> {
 	let encoding = detect_database_encoding(users_sample);
 
 	// Get a stream of all users
-	let mut stream = zitadel.list_users()?;
+	let mut stream = pin!(zitadel.list_users()?);
 
 	// Process each user
 	while let Some((user, zitadel_id)) = get_next_zitadel_user(&mut stream, &mut zitadel).await? {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@ mod sources;
 pub mod user;
 pub mod zitadel;
 
-use std::collections::VecDeque;
+use std::{collections::VecDeque, pin::pin};
 
 pub use config::{Config, FeatureFlag, LdapSourceConfig};
 pub use sources::{
@@ -126,7 +126,7 @@ async fn disable_users(config: &Config, users: &mut VecDeque<User>) -> Result<()
 	users.retain(|user| !user.enabled);
 
 	let mut zitadel = Zitadel::new(config).await?;
-	let mut stream = zitadel.list_users()?;
+	let mut stream = pin!(zitadel.list_users()?);
 
 	while let Some(zitadel_user) = get_next_zitadel_user(&mut stream, &mut zitadel).await? {
 		if users.front().map(|user| user.external_user_id.clone())
@@ -147,7 +147,7 @@ async fn sync_users(config: &Config, sync_users: &mut VecDeque<User>) -> Result<
 	sync_users.retain(|user| user.enabled);
 
 	let mut zitadel = Zitadel::new(config).await?;
-	let mut stream = zitadel.list_users()?;
+	let mut stream = pin!(zitadel.list_users()?);
 
 	let mut source_user = sync_users.pop_front();
 	let mut zitadel_user = get_next_zitadel_user(&mut stream, &mut zitadel).await?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -111,7 +111,7 @@ pub async fn perform_sync(config: &Config) -> Result<()> {
 /// Delete a list of users given their email addresses
 async fn delete_users_by_email(config: &Config, emails: Vec<String>) -> Result<()> {
 	let mut zitadel = Zitadel::new(config).await?;
-	let mut stream = zitadel.get_users_by_email(emails)?;
+	let mut stream = pin!(zitadel.get_users_by_email(emails)?);
 
 	while let Some(zitadel_user) = get_next_zitadel_user(&mut stream, &mut zitadel).await? {
 		zitadel.delete_user(&zitadel_user.1).await?;

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -502,6 +502,10 @@ async fn test_e2e_sync_deletion() {
 
 	let user = zitadel.get_user_by_login_name("deleted@famedly.de").await;
 	assert!(user.is_err_and(|error| matches!(error, ZitadelError::TonicResponseError(status) if status.code() == TonicErrorCode::NotFound)));
+
+	assert!(zitadel.get_user_by_login_name("another_user@example.test").await.is_ok());
+	assert!(zitadel.get_user_by_login_name("projectless_user@example.test").await.is_ok());
+	assert!(zitadel.get_user_by_login_name("another_org_user@example.test").await.is_ok());
 }
 
 #[test(tokio::test)]

--- a/tests/environment/config.template.yaml
+++ b/tests/environment/config.template.yaml
@@ -1,9 +1,9 @@
 zitadel:
   url: http://localhost:8080
   key_file: tests/environment/zitadel/service-user.json
-  organization_id: @ORGANIZATION_ID@
-  project_id: @PROJECT_ID@
-  idp_id: @IDP_ID@
+  organization_id: <ORGANIZATION_ID>
+  project_id: <PROJECT_ID>
+  idp_id: <IDP_ID>
 
 feature_flags:
   - sso_login

--- a/tests/environment/test-setup.sh
+++ b/tests/environment/test-setup.sh
@@ -14,7 +14,9 @@ LDAP_PASSWORD='adminpassword'
 
 ZITADEL_HOST="http://zitadel:8080"
 
-echo "Waiting for LDAP to be ready"
+log() { echo "$@" 1>&2; }
+
+log "Waiting for LDAP to be ready"
 
 retries=5
 
@@ -27,9 +29,10 @@ while [ $retries -gt 0 ]; do
 	fi
 done
 
-echo "Authenticating to Zitadel"
+log "Authenticating to Zitadel"
 zitadel-tools key2jwt --audience="http://localhost" --key=/environment/zitadel/service-user.json --output=/tmp/jwt.txt
-zitadel_token="$(curl -s \
+zitadel_token="$(curl -sS \
+	--fail-with-body \
 	--request POST \
 	--url "${ZITADEL_HOST}/oauth/v2/token" \
 	--header 'Content-Type: application/x-www-form-urlencoded' \
@@ -46,39 +49,40 @@ zitadel_request() {
 
 	shift 2
 
-	curl -s \
+	curl -sS \
+		--fail-with-body \
 		--request "$_request_type" \
 		--url "${ZITADEL_HOST}/${_path}" \
 		--header 'Host: localhost' \
 		--header "Authorization: Bearer ${zitadel_token}" \
-		"$@"
+		"$@" || exit 1
 }
 
-echo "Deleting Zitadel users"
+log "Deleting Zitadel users"
 zitadel_users="$(zitadel_request management/v1/users/_search POST)"
 # Filter out the admin users
 zitadel_users="$(echo "$zitadel_users" | jq --raw-output '.result[]? | select(.userName | startswith("zitadel-admin") | not) | .id')"
 
 for id in $zitadel_users; do
-	echo "Deleting user $id"
+	log "Deleting user $id"
 	zitadel_request "management/v1/users/$id" DELETE
 done
 
-echo "Deleting Zitadel projects"
+log "Deleting Zitadel projects"
 projects="$(zitadel_request 'management/v1/projects/_search' POST)"
 # Filter out the ZITADEL project
 projects="$(echo "$projects" | jq --raw-output '.result[]? | select(.name == "ZITADEL" | not) | .id')"
 
 for id in $projects; do
-	echo "Deleting project $id"
+	log "Deleting project $id"
 	zitadel_request "management/v1/projects/$id" DELETE
 done
 
-echo "Creating test project"
+log "Creating test project"
 project_id="$(zitadel_request 'management/v1/projects' POST --data '{"name": "TestProject"}' | jq --raw-output '.id')"
 zitadel_request "management/v1/projects/$project_id/roles" POST --data '{"roleKey": "User", "displayName": "User"}'
 
-echo "Setting up ldap IDP"
+log "Setting up ldap IDP"
 idp_id="$(zitadel_request 'management/v1/idps/ldap' POST --json @- <<EOF | jq --raw-output '.id'
 {
     "name": "ldap",
@@ -100,23 +104,25 @@ idp_id="$(zitadel_request 'management/v1/idps/ldap' POST --json @- <<EOF | jq --
 EOF
 )"
 
-echo "Updating Zitadel IDs"
+log "Updating Zitadel IDs"
 org_id="$(zitadel_request 'management/v1/orgs/me' GET | jq --raw-output '.org.id')"
 
-sed "s/@ORGANIZATION_ID@/$org_id/" /config.template.yaml > /environment/config.yaml
-sed "s/@PROJECT_ID@/$project_id/" -i /environment/config.yaml
-sed "s/@IDP_ID@/$idp_id/" -i /environment/config.yaml
+sed -f - /config.template.yaml > /environment/config.yaml <<EOF
+	s/<ORGANIZATION_ID>/$org_id/;
+	s/<PROJECT_ID>/$project_id/;
+	s/<IDP_ID>/$idp_id/;
+EOF
 
-echo "Deleting LDAP test data"
+log "Deleting LDAP test data"
 ldapdelete -D "${LDAP_ADMIN}" -w "${LDAP_PASSWORD}" -H "${LDAP_HOST}" -r "ou=testorg,${LDAP_BASE}" || true
 
-echo "Add LDAP test organization"
+log "Add LDAP test organization"
 ldapadd -D "${LDAP_ADMIN}" -w "${LDAP_PASSWORD}" -H "${LDAP_HOST}" -f /environment/ldap/testorg.ldif
 
-echo "Current LDAP test org data:"
+log "Current LDAP test org data:"
 ldapsearch -D "${LDAP_ADMIN}" -w "${LDAP_PASSWORD}" -H "${LDAP_HOST}" -b "ou=testorg,${LDAP_BASE}" "objectclass=*"
 
-echo "Current Zitadel org users:"
+log "Current Zitadel org users:"
 zitadel_request management/v1/users/_search POST | jq .result
 
 # Signify that the script has completed

--- a/tests/environment/test-setup.sh
+++ b/tests/environment/test-setup.sh
@@ -78,9 +78,98 @@ for id in $projects; do
 	zitadel_request "management/v1/projects/$id" DELETE
 done
 
+log "Checking if Zitadel another organization exists"
+another_org="$(zitadel_request 'v2/organizations/_search' POST \
+	--json '{"query": {"limit": 1000, "offset": 0}, "queries": [{"nameQuery": {"name": "Rock factory"}}]}' \
+	| jq -r '.result[0].id')"
+log "Deleting Zitadel another organization $another_org"
+[ "$another_org" != 'null' ] && zitadel_request 'management/v1/orgs/me' DELETE -H "x-zitadel-orgid: $another_org"
+
 log "Creating test project"
-project_id="$(zitadel_request 'management/v1/projects' POST --data '{"name": "TestProject"}' | jq --raw-output '.id')"
-zitadel_request "management/v1/projects/$project_id/roles" POST --data '{"roleKey": "User", "displayName": "User"}'
+project_id="$(zitadel_request 'management/v1/projects' POST --json '{"name": "TestProject"}' | jq --raw-output '.id')"
+zitadel_request "management/v1/projects/$project_id/roles" POST --json '{"roleKey": "User", "displayName": "User"}'
+
+log "Creating another test project with a user"
+another_project_id="$( \
+	zitadel_request 'management/v1/projects' POST --json '{"name": "AnotherTestProject"}' \
+	| jq --raw-output '.id'
+)"
+
+zitadel_request "management/v1/projects/$another_project_id/roles" POST \
+	--json '{"roleKey": "User", "displayName": "User"}'
+
+seemingly_valid_external_uid=6261736536345f74657374
+another_user_id="$(zitadel_request "v2/users/human" POST --json @- <<EOF | jq --raw-output '.userId'
+{
+	"email": { "email": "another_user@example.test" },
+	"profile": {
+		"givenName": "Userino",
+		"familyName": "Anotherio",
+		"nickname": "$seemingly_valid_external_uid"
+	}
+}
+EOF
+)"
+
+zitadel_request "management/v1/users/$another_user_id/grants" POST --json @- <<EOF
+{
+	"projectId": "$another_project_id",
+	"roleKeys": ["User"]
+}
+EOF
+
+log "Creating a user not belonging to any project"
+seemingly_valid_external_uid=6261736536345f74657375
+projectless_user_id="$(zitadel_request "v2/users/human" POST --json @- <<EOF | jq --raw-output '.userId'
+{
+	"email": { "email": "projectless_user@example.test" },
+	"profile": {
+		"givenName": "Trampy",
+		"familyName": "Projectlessio",
+		"nickname": "$seemingly_valid_external_uid"
+	}
+}
+EOF
+)"
+
+log "Creating another organization"
+seemingly_valid_external_uid=6261736536345f74657376
+org_res="$(zitadel_request "v2/organizations" POST --json @- <<EOF
+{
+	"name": "Rock factory",
+	"admins": [{ "human": {
+		"email": { "email": "another_org_user@example.test" },
+		"profile": {
+			"givenName": "Userinus",
+			"familyName": "Anotherson",
+			"nickname": "$seemingly_valid_external_uid"
+		}
+	}}]
+}
+EOF
+)"
+another_org_id=$(echo "$org_res" | jq --raw-output '.organizationId')
+another_org_user_id=$(echo "$org_res" | jq --raw-output '.createdAdmins[0].userId')
+
+log "Creating a project in another organization, granting a user into there"
+another_org_project_id="$( \
+	zitadel_request 'management/v1/projects' POST \
+	-H "x-zitadel-orgid: $another_org_id" \
+	--json '{"name": "RocksResearchProject"}' \
+	| jq --raw-output '.id'
+)"
+
+zitadel_request "management/v1/projects/$another_org_project_id/roles" POST \
+	-H "x-zitadel-orgid: $another_org_id" \
+	--json '{"roleKey": "User", "displayName": "User"}'
+
+zitadel_request "management/v1/users/$another_org_user_id/grants" POST \
+	-H "x-zitadel-orgid: $another_org_id" --json @- <<EOF
+{
+	"projectId": "$another_org_project_id",
+	"roleKeys": ["User"]
+}
+EOF
 
 log "Setting up ldap IDP"
 idp_id="$(zitadel_request 'management/v1/idps/ldap' POST --json @- <<EOF | jq --raw-output '.id'


### PR DESCRIPTION
Closes #103
Depends on [feat: add `list_project_grant_members` method by sirewix · famedly/zitadel-rust-client#55](https://github.com/famedly/zitadel-rust-client/pull/55)
Alternative to #114 as that approach seem to be impossible to implement in a reasonable time due to zitadel's [*Search User Grants*](https://zitadel.com/docs/apis/resources/mgmt/management-service-list-user-grants) not returning nickname (and phone)