### PR TITLE
refactor: Make IDP value optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ certificates.
 
 ## Deployment
 
-The easiest way to deploy this tool is using our published docker
+The easiest way to run this tool is using our published docker
 container through our [composefile](./docker-compose.yaml).
 
 To prepare for use, we need to provide a handful of files in an `opt`
@@ -214,6 +214,8 @@ opt
 ├── certs
 │  └── test-ldap.crt   # The TLS certificate of the LDAP server
 ├── config.yaml        # Example configs can be found in [./sample-configs](./sample-configs)
+├── csv
+│  └── users.csv       # Optional: if using CSV source, this would hold the user data
 └── service-user.json  # Provided by famedly
 ```
 
@@ -229,6 +231,9 @@ Or alternatively, without `docker compose`:
 ```
 docker run --rm -it --network host --volume ./opt:/opt/famedly-sync docker-oss.nexus.famedly.de/famedly-sync-agent:latest
 ```
+
+> [!NOTE]
+> Famedly can provide a pre-recorded walkthrough video of this process upon request.
 
 ### Kubernetes Deployment
 

--- a/sample-configs/ad-config.sample.yaml
+++ b/sample-configs/ad-config.sample.yaml
@@ -7,12 +7,16 @@ zitadel:
   organization_id: 000000000000000000
   # The project to grant users access to.
   project_id: 000000000000000000
-  # The identity provider ID to enable SSO login for
-  idp_id: 000000000000000000
+  # The identity provider ID to enable SSO login for (only required when sso_login feature flag is enabled)
+  #
+  # WARNING: This user *must* be scoped to the specific org/project,
+  # as famedly-sync does not limit syncs to the configured org/project
+  # by itself.
+  # idp_id: 000000000000000000
 
 feature_flags:
-  - verify_email      # Whether to ask users to verify their email addresses post sync
-  - verify_phone      # Whether to ask users to verify their phone numbers post sync
+  - verify_email # Whether to ask users to verify their email addresses post sync
+  - verify_phone # Whether to ask users to verify their phone numbers post sync
   # - sso_login       # Whether to enable SSO login - Please note that his has some drawbacks and limitations, see the help center article for more information
   # - dry_run         # Disable syncing users to Zitadel - Intended to ensure syncs are working before productive deployment
   # - deactivate_only # Only deactivate users, do not create or update them.
@@ -74,7 +78,7 @@ sources:
       #
       # Microsoft define the meaning of their bits here:
       # https://learn.microsoft.com/en-us/troubleshoot/windows-server/active-directory/useraccountcontrol-manipulate-account-properties#list-of-property-flags
-      disable_bitmasks: [0x2,0x10]
+      disable_bitmasks: [0x2, 0x10]
       # Phone numbers are the only optional attribute, if a user does
       # not have a phone number this will be silently ignored
       phone: "telephoneNumber"

--- a/sample-configs/csv-config.sample.yaml
+++ b/sample-configs/csv-config.sample.yaml
@@ -8,16 +8,16 @@ zitadel:
   organization_id: 278274756195721220
   # The project to grant users access to.
   project_id: 278274945274880004
-  # The identity provider ID to enable SSO login for
+  # The identity provider ID to enable SSO login for (only required when sso_login feature flag is enabled)
   #
   # WARNING: This user *must* be scoped to the specific org/project,
   # as famedly-sync does not limit syncs to the configured org/project
   # by itself.
-  idp_id: 281430143275106308
+  # idp_id: 000000000000000000
 
 feature_flags:
-  - verify_email      # Whether to ask users to verify their email addresses post sync
-  - verify_phone      # Whether to ask users to verify their phone numbers post sync
+  - verify_email # Whether to ask users to verify their email addresses post sync
+  - verify_phone # Whether to ask users to verify their phone numbers post sync
   # - sso_login       # Whether to enable SSO login - Please note that his has some drawbacks and limitations, see the help center article for more information
   # - dry_run         # Disable syncing users to Zitadel - Intended to ensure syncs are working before productive deployment
   # - deactivate_only # Only deactivate users, do not create or update them.
@@ -30,5 +30,5 @@ sources:
   csv:
     # Path to the CSV file to read from.
     # Expected structure of the CSV file is as follows:
-    # email,first_name,last_name,phone
-    file_path:  ./tests/environment/files/test-users.csv
+    # email,first_name,last_name,phone,localpart (localpart is optional)
+    file_path: /opt/famedly-sync/csv/users.csv

--- a/sample-configs/ldap-config.sample.yaml
+++ b/sample-configs/ldap-config.sample.yaml
@@ -8,7 +8,7 @@ zitadel:
   organization_id: 278274756195721220
   # The project to grant users access to.
   project_id: 278274945274880004
-  # The identity provider ID to enable SSO login for
+  # The identity provider ID to enable SSO login for (only required when sso_login feature flag is enabled)
   #
   # WARNING: This user *must* be scoped to the specific org/project,
   # as famedly-sync does not limit syncs to the configured org/project

--- a/sample-configs/ukt-config.sample.yaml
+++ b/sample-configs/ukt-config.sample.yaml
@@ -8,12 +8,12 @@ zitadel:
   organization_id: 278274756195721220
   # The project to grant users access to.
   project_id: 278274945274880004
-  # The identity provider ID to enable SSO login for
+  # The identity provider ID to enable SSO login for (only required when sso_login feature flag is enabled)
   #
   # WARNING: This user *must* be scoped to the specific org/project,
   # as famedly-sync does not limit syncs to the configured org/project
   # by itself.
-  idp_id: 281430143275106308
+  # idp_id: 000000000000000000
 
 feature_flags:
   - verify_email      # Whether to ask users to verify their email addresses post sync

--- a/src/sources/csv.rs
+++ b/src/sources/csv.rs
@@ -135,7 +135,6 @@ mod tests {
           key_file: tests/environment/zitadel/service-user.json
           organization_id: 1
           project_id: 1
-          idp_id: 1
 
         sources:
           csv:

--- a/src/sources/ldap.rs
+++ b/src/sources/ldap.rs
@@ -441,7 +441,6 @@ mod tests {
           key_file: tests/environment/zitadel/service-user.json
           organization_id: 1
           project_id: 1
-          idp_id: 1
 
         sources:
           ldap:

--- a/src/sources/ukt.rs
+++ b/src/sources/ukt.rs
@@ -196,7 +196,6 @@ mod tests {
           key_file: tests/environment/zitadel/service-user.json
           organization_id: 1
           project_id: 1
-          idp_id: 1
 
         sources:
           ukt:

--- a/src/zitadel.rs
+++ b/src/zitadel.rs
@@ -225,10 +225,15 @@ impl<'s> Zitadel<'s> {
 		};
 
 		if self.feature_flags.is_enabled(FeatureFlag::SsoLogin) {
+			let idp_id = self
+				.zitadel_config
+				.idp_id
+				.as_ref()
+				.context("idp_id is required when sso_login feature flag is enabled")?;
 			user.set_idp_links(vec![
 				IdpLink::new()
 					.with_user_id(get_zitadel_encoded_id(imported_user.get_external_id_bytes()?))
-					.with_idp_id(self.zitadel_config.idp_id.clone())
+					.with_idp_id(idp_id.clone())
 					.with_user_name(imported_user.email.clone()),
 			]);
 		}
@@ -520,6 +525,6 @@ pub struct ZitadelConfig {
 	pub organization_id: String,
 	/// Project ID provided by Famedly Zitadel
 	pub project_id: String,
-	/// IDP ID provided by Famedly Zitadel
-	pub idp_id: String,
+	/// IDP ID provided by Famedly Zitadel (only required when SSO is enabled)
+	pub idp_id: Option<String>,
 }

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -1438,7 +1438,11 @@ async fn test_e2e_sso_linking() {
 	assert!(!idps.is_empty(), "User should have IDP links");
 
 	let idp = idps.first().expect("No IDP link found");
-	assert_eq!(idp.idp_id, config.zitadel.idp_id, "IDP link should match configured IDP");
+	assert_eq!(
+		idp.idp_id,
+		*config.zitadel.idp_id.as_ref().unwrap(),
+		"IDP link should match configured IDP"
+	);
 	assert_eq!(idp.provided_user_id, test_uid, "IDP provided_user_id should match plain LDAP uid");
 	assert_eq!(idp.user_id, user.id, "IDP user_id should match Zitadel user id");
 	assert_eq!(


### PR DESCRIPTION
Based on discussion with @chrismafam, this will make the `zitadel.idp_id` value optional and required only when the `sso_login` feature flag is enabled.